### PR TITLE
feature/NDT-11/Paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - **Version 2.2 (breaking changes from 2.1.x)**
 
   - 2.2.0:
+    - Removed Den Haag paragraph.
     - Removed Den Haag Table imports from CreateKeyValue component.
     - Removed EditableTableRow component.
     - Removed Den Haag divider.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conduction/components",
-  "version": "2.1.40",
+  "version": "2.2.0",
   "description": "React (Gatsby) components used within the Conduction Skeleton Application (and its implementations)",
   "main": "lib/index.js",
   "scripts": {

--- a/src/components/notificationPopUp/NotificationPopUp.tsx
+++ b/src/components/notificationPopUp/NotificationPopUp.tsx
@@ -2,11 +2,12 @@ import * as React from "react";
 import * as styles from "./NotificationPopUp.module.css";
 import ReactDOM from "react-dom";
 import { Button } from "@gemeente-denhaag/button";
-import { Heading3, Paragraph } from "@gemeente-denhaag/typography";
+import { Heading3 } from "@gemeente-denhaag/typography";
 import { Link } from "@gemeente-denhaag/link";
 import { StylesProvider } from "@gemeente-denhaag/stylesprovider";
 import clsx from "clsx";
 import { CloseIcon, ArrowRightIcon } from "@gemeente-denhaag/icons";
+import { Paragraph } from "@utrecht/component-library-react";
 
 export interface NotificationPopUpProps {
   title: string;


### PR DESCRIPTION
Note: There are still imports from `"@gemeente-denhaag/typography": "0.2.3-alpha.205",` so it can not be removed yet.
