### PR TITLE
REFACTOR ToolTip component to new react version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 - **Version 2.2 (breaking changes from 2.1.x)**
 
+  - 2.2.4: Refactor the Tooltip component to include react-tooltip version 5+.
   - 2.2.3: Added Tabs component.
   - 2.2.2:
     - Removed Den Haag Textfield dependencies.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@conduction/components",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@conduction/components",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "license": "ISC",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.2.0",
@@ -21,7 +21,7 @@
         "react-paginate": "^8.2.0",
         "react-select": "5.3.2",
         "react-tabs": "^6.0.2",
-        "react-tooltip": "^4.2.21"
+        "react-tooltip": "^5.21.3"
       },
       "devDependencies": {
         "@types/node": "^17.0.23",
@@ -2313,6 +2313,28 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.4.1.tgz",
+      "integrity": "sha512-jk3WqquEJRlcyu7997NtR5PibI+y5bi+LS3hPmguVClypenMsCY3CBa3LAQnozRCtCrYWSEtAdiskpamuJRFOQ==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.1.1"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.2.tgz",
+      "integrity": "sha512-6ArmenS6qJEWmwzczWyhvrXRdI/rI78poBcW0h/456+onlabit+2G+QxHx5xTOX60NBJQXjsCLFbW2CmsXpUog==",
+      "dependencies": {
+        "@floating-ui/core": "^1.4.1",
+        "@floating-ui/utils": "^0.1.1"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.2.tgz",
+      "integrity": "sha512-ou3elfqG/hZsbmF4bxeJhPHIf3G2pm0ujc39hYEZrfVqt7Vk/Zji6CXc3W0pmYM8BW1g40U+akTl9DKZhFhInQ=="
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
       "version": "6.2.0",
@@ -13532,27 +13554,16 @@
       }
     },
     "node_modules/react-tooltip": {
-      "version": "4.2.21",
-      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-4.2.21.tgz",
-      "integrity": "sha512-zSLprMymBDowknr0KVDiJ05IjZn9mQhhg4PRsqln0OZtURAJ1snt1xi5daZfagsh6vfsziZrc9pErPTDY1ACig==",
+      "version": "5.21.3",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.21.3.tgz",
+      "integrity": "sha512-z3Q+Uka4D6uYxfsssPqfx1W8vw7NIHyC2ZMq+NJkWg4EpUD3w7Fwz/o+dezyUQMCHL7nO/2sFbtWIrkyxktq2Q==",
       "dependencies": {
-        "prop-types": "^15.7.2",
-        "uuid": "^7.0.3"
-      },
-      "engines": {
-        "npm": ">=6.13"
+        "@floating-ui/dom": "^1.0.0",
+        "classnames": "^2.3.0"
       },
       "peerDependencies": {
-        "react": ">=16.0.0",
-        "react-dom": ">=16.0.0"
-      }
-    },
-    "node_modules/react-tooltip/node_modules/uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
       }
     },
     "node_modules/react-transition-group": {
@@ -18019,6 +18030,28 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
+    },
+    "@floating-ui/core": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.4.1.tgz",
+      "integrity": "sha512-jk3WqquEJRlcyu7997NtR5PibI+y5bi+LS3hPmguVClypenMsCY3CBa3LAQnozRCtCrYWSEtAdiskpamuJRFOQ==",
+      "requires": {
+        "@floating-ui/utils": "^0.1.1"
+      }
+    },
+    "@floating-ui/dom": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.2.tgz",
+      "integrity": "sha512-6ArmenS6qJEWmwzczWyhvrXRdI/rI78poBcW0h/456+onlabit+2G+QxHx5xTOX60NBJQXjsCLFbW2CmsXpUog==",
+      "requires": {
+        "@floating-ui/core": "^1.4.1",
+        "@floating-ui/utils": "^0.1.1"
+      }
+    },
+    "@floating-ui/utils": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.2.tgz",
+      "integrity": "sha512-ou3elfqG/hZsbmF4bxeJhPHIf3G2pm0ujc39hYEZrfVqt7Vk/Zji6CXc3W0pmYM8BW1g40U+akTl9DKZhFhInQ=="
     },
     "@fortawesome/fontawesome-common-types": {
       "version": "6.2.0",
@@ -26234,19 +26267,12 @@
       }
     },
     "react-tooltip": {
-      "version": "4.2.21",
-      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-4.2.21.tgz",
-      "integrity": "sha512-zSLprMymBDowknr0KVDiJ05IjZn9mQhhg4PRsqln0OZtURAJ1snt1xi5daZfagsh6vfsziZrc9pErPTDY1ACig==",
+      "version": "5.21.3",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.21.3.tgz",
+      "integrity": "sha512-z3Q+Uka4D6uYxfsssPqfx1W8vw7NIHyC2ZMq+NJkWg4EpUD3w7Fwz/o+dezyUQMCHL7nO/2sFbtWIrkyxktq2Q==",
       "requires": {
-        "prop-types": "^15.7.2",
-        "uuid": "^7.0.3"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
-        }
+        "@floating-ui/dom": "^1.0.0",
+        "classnames": "^2.3.0"
       }
     },
     "react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conduction/components",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "React (Gatsby) components used within the Conduction Skeleton Application (and its implementations)",
   "main": "lib/index.js",
   "scripts": {
@@ -12,12 +12,7 @@
     "type": "git",
     "url": "git+https://github.com/ConductionNL/conduction-components.git"
   },
-  "keywords": [
-    "React",
-    "Gatsby",
-    "Conduction",
-    "Components"
-  ],
+  "keywords": ["React", "Gatsby", "Conduction", "Components"],
   "author": "Conduction B.V.",
   "license": "ISC",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "react-paginate": "^8.2.0",
     "react-select": "5.3.2",
     "react-tabs": "^6.0.2",
-    "react-tooltip": "^4.2.21"
+    "react-tooltip": "^5.21.3"
   },
   "devDependencies": {
     "@types/node": "^17.0.23",

--- a/src/components/formFields/createKeyValue/CreateKeyValue.tsx
+++ b/src/components/formFields/createKeyValue/CreateKeyValue.tsx
@@ -12,7 +12,6 @@ import {
   Textbox,
   Button,
 } from "@utrecht/component-library-react/dist/css-module";
-import { ToolTip } from "../../toolTip/ToolTip";
 import clsx from "clsx";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCopy, faTrash } from "@fortawesome/free-solid-svg-icons";
@@ -133,25 +132,21 @@ const KeyValueComponent = ({
                 <TableCell>
                   <div className={styles.buttonsContainer}>
                     {copyValue && (
-                      <ToolTip tooltip="Copy value">
-                        <Button
-                          {...{ disabled }}
-                          onClick={() => handleCopyToClipboard(keyValue.value, idx)}
-                          appearance={currentCopyIdx === idx ? "secondary-action-button" : "primary-action-button"}
-                        >
-                          <FontAwesomeIcon icon={faCopy} />
-                        </Button>
-                      </ToolTip>
-                    )}
-                    <ToolTip tooltip="Delete value">
                       <Button
                         {...{ disabled }}
-                        onClick={() => setKeyValues(keyValues.filter((_keyValue) => _keyValue !== keyValue))}
-                        className={clsx(styles.deleteButton)}
+                        onClick={() => handleCopyToClipboard(keyValue.value, idx)}
+                        appearance={currentCopyIdx === idx ? "secondary-action-button" : "primary-action-button"}
                       >
-                        <FontAwesomeIcon icon={faTrash} />
+                        <FontAwesomeIcon icon={faCopy} />
                       </Button>
-                    </ToolTip>
+                    )}
+                    <Button
+                      {...{ disabled }}
+                      onClick={() => setKeyValues(keyValues.filter((_keyValue) => _keyValue !== keyValue))}
+                      className={clsx(styles.deleteButton)}
+                    >
+                      <FontAwesomeIcon icon={faTrash} />
+                    </Button>
                   </div>
                 </TableCell>
               </TableRow>

--- a/src/components/toolTip/ToolTip.module.css
+++ b/src/components/toolTip/ToolTip.module.css
@@ -1,17 +1,1 @@
-:root {
-  --conduction-tooltip-max-width: 500px;
-}
-
-.wrapper {
-  display: inline-block;
-  position: relative;
-}
-
-.tooltip {
-  max-width: var(--conduction-tooltip-max-width);
-  word-break: break-word;
-}
-
-.tooltip::before {
-  all: unset !important;
-}
+/* to-do */

--- a/src/components/toolTip/ToolTip.module.css
+++ b/src/components/toolTip/ToolTip.module.css
@@ -1,1 +1,33 @@
-/* to-do */
+:root {
+  --conduction-tooltip-padding-inline-start: 0px;
+  --conduction-tooltip-padding-inline-end: 0px;
+  --conduction-tooltip-padding-block-start: 0px;
+  --conduction-tooltip-padding-block-end: 0px;
+
+  --conduction-tooltip-background-color: var(--skeleton-color-black);
+  --conduction-tooltip-color: var(--skeleton-color-white);
+
+  --conduction-tooltip-border-width: 0px;
+  --conduction-tooltip-border-color: unset;
+  --conduction-tooltip-border-style: unset;
+  --conduction-tooltip-border-radius: 0px;
+
+  --conduction-tooltip-opacity: 1;
+}
+
+.tooltip {
+  padding-inline-start: var(--conduction-tooltip-padding-inline-start);
+  padding-inline-end: var(--conduction-tooltip-padding-inline-end);
+  padding-block-start: var(--conduction-tooltip-padding-block-start);
+  padding-block-end: var(--conduction-tooltip-padding-block-end);
+
+  background-color: var(--conduction-tooltip-background-color) !important;
+  color: var(--conduction-tooltip-color) !important;
+
+  border-width: var(--conductino-tooltip-border-width);
+  border-color: var(--conduction-tooltip-border-color);
+  border-style: var(--conduction-tooltip-border-style);
+  border-radius: var(--conduction-tooltip-border-radius) !important;
+
+  opacity: var(--conduction-tooltip-opacity);
+}

--- a/src/components/toolTip/ToolTip.tsx
+++ b/src/components/toolTip/ToolTip.tsx
@@ -7,8 +7,11 @@ interface ToolTipProps {
 }
 
 /**
- * This ToolTip should only be implemented once, after implementing it can be used in any element, like so:
- * <AnyElement data-tooltip-id="id-that-was-passed-to-ToolTip" data-tooltip-content="Hello world!" />
+ * Implement this ToolTip only once, in a high-level wrapper.
+ * Use the ToolTip anywhere, in any element, by setting the following data props:
+ *
+ * data-tooltip-id="this-is-the-id-set-in-ToolTipProps"
+ * data-tooltip-content="Hello world!"
  */
 
 export const ToolTip: React.FC<ToolTipProps> = ({ id }) => {

--- a/src/components/toolTip/ToolTip.tsx
+++ b/src/components/toolTip/ToolTip.tsx
@@ -1,23 +1,16 @@
-import clsx from "clsx";
-import _ from "lodash";
 import * as React from "react";
-import ReactTooltip from "react-tooltip";
 import * as styles from "./ToolTip.module.css";
+import { Tooltip } from "react-tooltip";
 
 interface ToolTipProps {
-  children: React.ReactNode;
-  tooltip: string;
-  layoutClassName?: string;
+  id: string;
 }
 
-export const ToolTip = ({ children, layoutClassName, tooltip }: React.PropsWithChildren<ToolTipProps>): JSX.Element => {
-  return (
-    <div className={clsx(styles.wrapper, layoutClassName && layoutClassName)}>
-      <div data-tip={tooltip}>{children}</div>
+/**
+ * This ToolTip should only be implemented once, after implementing it can be used in any element, like so:
+ * <AnyElement data-tooltip-id="id-that-was-passed-to-ToolTip" data-tooltip-content="Hello world!" />
+ */
 
-      <ReactTooltip place={"top"} type={"dark"} effect={"solid"} className={styles.tooltip} />
-    </div>
-  );
+export const ToolTip: React.FC<ToolTipProps> = ({ id }) => {
+  return <Tooltip className={styles.tooltip} {...{ id }} />;
 };
-
-export { ReactTooltip };


### PR DESCRIPTION
This pull request:

- Upgrades the `react-tooltip` version to 5+;
- Removes old, now redundant styling.

To-do:

- [x] Add design tokens.


These changes are implemented in this pull request: https://github.com/OpenCatalogi/web-app/pull/324.