### PR TITLE
WOO-479 - Added feature to Select to configure clear button attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 - **Version 2.2 (breaking changes from 2.1.x)**
 
-  - 2.2.58: Added feature to Select to configure clear button attributes
+  - 2.2.58:
+    - Added feature to Select to configure clear button attributes
+    - Fixed pagination having nested interactive elements
   - 2.2.57: 
     - Fixed clear button on SelectSingle not being clickable with keyboard functions.
     - Fixed Logo not being focusable when being clickable.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 - **Version 2.2 (breaking changes from 2.1.x)**
 
+  - 2.2.58: Added feature to Select to configure clear button attributes
   - 2.2.57: 
     - Fixed clear button on SelectSingle not being clickable with keyboard functions.
     - Fixed Logo not being focusable when being clickable.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@conduction/components",
-  "version": "2.2.57",
+  "version": "2.2.58",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@conduction/components",
-      "version": "2.2.57",
+      "version": "2.2.58",
       "license": "ISC",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@conduction/components",
-  "version": "2.2.53",
+  "version": "2.2.57",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@conduction/components",
-      "version": "2.2.53",
+      "version": "2.2.57",
       "license": "ISC",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conduction/components",
-  "version": "2.2.57",
+  "version": "2.2.58",
   "description": "React (Gatsby) components used within the Conduction Skeleton Application (and its implementations)",
   "main": "lib/index.js",
   "scripts": {

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -3,7 +3,7 @@ import * as styles from "./Pagination.module.css";
 import clsx from "clsx";
 
 import ReactPaginate from "react-paginate";
-import { Button } from "@utrecht/component-library-react";
+
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChevronRight, faChevronLeft } from "@fortawesome/free-solid-svg-icons";
 
@@ -73,14 +73,14 @@ export const Pagination: React.FC<PaginationProps> = ({
       previousAriaLabel={ariaLabels.previousPage}
       ariaLabelBuilder={(currentPage) => `${ariaLabels.page} ${currentPage}`}
       nextLabel={
-        <Button tabIndex={-1} className={styles.button} aria-label={ariaLabels.nextPage}>
+        <span className={clsx("utrecht-button", styles.button)} aria-hidden="true">
           <FontAwesomeIcon icon={faChevronRight} />
-        </Button>
+        </span>
       }
       previousLabel={
-        <Button tabIndex={-1} className={styles.button} aria-label={ariaLabels.previousPage}>
+        <span className={clsx("utrecht-button", styles.button)} aria-hidden="true">
           <FontAwesomeIcon icon={faChevronLeft} />
-        </Button>
+        </span>
       }
     />
   );

--- a/src/components/formFields/select/select.tsx
+++ b/src/components/formFields/select/select.tsx
@@ -72,10 +72,8 @@ const setAttributes = (
 ): void => {
   const setRoleToPresentation = (selector: string, role: string) => {
     root.querySelectorAll(selector).forEach((element) => {
-      if (element.getAttribute("role") !== "presentation") element.setAttribute("role", role);
-      element.removeAttribute("aria-relevant");
-      element.removeAttribute("aria-atomic");
-      element.removeAttribute("aria-live");
+      const currentRole = element.getAttribute("role");
+      if (currentRole !== "presentation" && currentRole !== "listbox") element.setAttribute("role", role);
     });
   };
 
@@ -112,9 +110,7 @@ const setAttributes = (
   };
 
   // Initial static setup
-  setRoleToPresentation('[id*="live-region"]', "presentation");
   setRoleToPresentation('[class*="indicatorSeparator"]', "separator");
-  setRoleToPresentation('[class*="a11yText"]', "presentation");
 
   // Dynamic setup after render
   setTimeout(() => {

--- a/src/components/formFields/select/select.tsx
+++ b/src/components/formFields/select/select.tsx
@@ -22,6 +22,7 @@ interface ISelectProps {
   hideErrorMessage?: boolean;
   menuPlacement?: MenuPlacement;
   placeholder?: string;
+  clearIndicatorAttributes?: Record<string, string>;
 }
 
 const selectStyles: StylesConfig = {
@@ -65,9 +66,12 @@ const selectStyles: StylesConfig = {
   }),
 };
 
-const setAttributes = (): void => {
+const setAttributes = (
+  root: HTMLElement | Document = document,
+  clearIndicatorAttributes?: Record<string, string>,
+): void => {
   const setRoleToPresentation = (selector: string, role: string) => {
-    document.querySelectorAll(selector).forEach((element) => {
+    root.querySelectorAll(selector).forEach((element) => {
       if (element.getAttribute("role") !== "presentation") element.setAttribute("role", role);
       element.removeAttribute("aria-relevant");
       element.removeAttribute("aria-atomic");
@@ -80,6 +84,11 @@ const setAttributes = (): void => {
       indicator.setAttribute("role", "button");
       indicator.setAttribute("tabindex", "0");
       indicator.setAttribute("aria-label", "Clear selection");
+      if (clearIndicatorAttributes) {
+        Object.entries(clearIndicatorAttributes).forEach(([key, value]) => {
+          indicator.setAttribute(key, value);
+        });
+      }
     } else {
       indicator.setAttribute("role", "presentation");
       indicator.removeAttribute("tabindex");
@@ -88,7 +97,7 @@ const setAttributes = (): void => {
   };
 
   const setAriaLabelsForIndicators = () => {
-    document.querySelectorAll('[class*="control"]').forEach((control) => {
+    root.querySelectorAll('[class*="control"]').forEach((control) => {
       const indicatorsParent = control.querySelector('[class*="indicatorSeparator"]')?.parentElement;
       if (!indicatorsParent) return;
 
@@ -113,7 +122,7 @@ const setAttributes = (): void => {
 
     const observer = new MutationObserver(setAriaLabelsForIndicators);
 
-    document.querySelectorAll('[class*="control"]').forEach((control) => {
+    root.querySelectorAll('[class*="control"]').forEach((control) => {
       const indicatorsParent = control.querySelector('[class*="indicatorSeparator"]')?.parentElement;
       if (indicatorsParent) {
         observer.observe(indicatorsParent, { childList: true, subtree: false });
@@ -167,36 +176,43 @@ export const SelectMultiple = ({
   menuPlacement,
   placeholder,
   ariaLabel,
+  clearIndicatorAttributes,
 }: ISelectProps & IReactHookFormProps): JSX.Element => {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
   React.useEffect(() => {
-    setAttributes();
+    if (containerRef.current) {
+      setAttributes(containerRef.current, clearIndicatorAttributes);
+    }
   }, []);
   return (
-    <Controller
-      {...{ control, name, defaultValue }}
-      rules={validation}
-      render={({ field: { onChange, value } }) => {
-        return (
-          <>
-            <ReactSelect
-              aria-label={ariaLabel}
-              inputId={id}
-              value={value ?? ""}
-              className={clsx(styles.select, errors[name] && styles.error)}
-              isMulti
-              isDisabled={disabled}
-              {...{ options, onChange, errors }}
-              menuPortalTarget={document.body}
-              menuPlacement={menuPlacement}
-              styles={selectStyles}
-              placeholder={disabled ? "Disabled..." : placeholder ?? "Select one or more options..."}
-              formatGroupLabel={(group) => <GroupLabel {...{ group }} />}
-            />
-            {errors[name] && !hideErrorMessage && <ErrorMessage message={errors[name]?.message as string} />}
-          </>
-        );
-      }}
-    />
+    <div ref={containerRef}>
+      <Controller
+        {...{ control, name, defaultValue }}
+        rules={validation}
+        render={({ field: { onChange, value } }) => {
+          return (
+            <>
+              <ReactSelect
+                aria-label={ariaLabel}
+                inputId={id}
+                value={value ?? ""}
+                className={clsx(styles.select, errors[name] && styles.error)}
+                isMulti
+                isDisabled={disabled}
+                {...{ options, onChange, errors }}
+                menuPortalTarget={document.body}
+                menuPlacement={menuPlacement}
+                styles={selectStyles}
+                placeholder={disabled ? "Disabled..." : placeholder ?? "Select one or more options..."}
+                formatGroupLabel={(group) => <GroupLabel {...{ group }} />}
+              />
+              {errors[name] && !hideErrorMessage && <ErrorMessage message={errors[name]?.message as string} />}
+            </>
+          );
+        }}
+      />
+    </div>
   );
 };
 
@@ -213,36 +229,43 @@ export const SelectCreate = ({
   menuPlacement,
   placeholder,
   ariaLabel,
+  clearIndicatorAttributes,
 }: ISelectProps & IReactHookFormProps): JSX.Element => {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
   React.useEffect(() => {
-    setAttributes();
+    if (containerRef.current) {
+      setAttributes(containerRef.current, clearIndicatorAttributes);
+    }
   }, []);
   return (
-    <Controller
-      {...{ control, name, defaultValue }}
-      rules={validation}
-      render={({ field: { onChange, value } }) => {
-        return (
-          <>
-            <CreatableSelect
-              aria-label={ariaLabel}
-              inputId={id}
-              value={value ?? ""}
-              placeholder={disabled ? "Disabled..." : placeholder ?? "Select one or more options..."}
-              className={clsx(styles.select, errors[name] && styles.error)}
-              isMulti
-              isDisabled={disabled}
-              {...{ options, onChange, errors }}
-              menuPortalTarget={document.body}
-              menuPlacement={menuPlacement}
-              styles={selectStyles}
-              formatGroupLabel={(group) => <GroupLabel {...{ group }} />}
-            />
-            {errors[name] && !hideErrorMessage && <ErrorMessage message={errors[name]?.message as string} />}
-          </>
-        );
-      }}
-    />
+    <div ref={containerRef}>
+      <Controller
+        {...{ control, name, defaultValue }}
+        rules={validation}
+        render={({ field: { onChange, value } }) => {
+          return (
+            <>
+              <CreatableSelect
+                aria-label={ariaLabel}
+                inputId={id}
+                value={value ?? ""}
+                placeholder={disabled ? "Disabled..." : placeholder ?? "Select one or more options..."}
+                className={clsx(styles.select, errors[name] && styles.error)}
+                isMulti
+                isDisabled={disabled}
+                {...{ options, onChange, errors }}
+                menuPortalTarget={document.body}
+                menuPlacement={menuPlacement}
+                styles={selectStyles}
+                formatGroupLabel={(group) => <GroupLabel {...{ group }} />}
+              />
+              {errors[name] && !hideErrorMessage && <ErrorMessage message={errors[name]?.message as string} />}
+            </>
+          );
+        }}
+      />
+    </div>
   );
 };
 
@@ -260,36 +283,43 @@ export const SelectSingle = ({
   menuPlacement,
   placeholder,
   ariaLabel,
+  clearIndicatorAttributes,
 }: ISelectProps & IReactHookFormProps): JSX.Element => {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
   React.useEffect(() => {
-    setAttributes();
+    if (containerRef.current) {
+      setAttributes(containerRef.current, clearIndicatorAttributes);
+    }
   }, []);
   return (
-    <Controller
-      {...{ control, name, defaultValue }}
-      rules={validation}
-      render={({ field: { onChange, value } }) => {
-        return (
-          <>
-            <ReactSelect
-              aria-label={ariaLabel}
-              inputId={id}
-              value={value ?? ""}
-              className={clsx(styles.select, errors[name] && styles.error)}
-              isDisabled={disabled}
-              {...{ options, onChange, errors, isClearable }}
-              menuPortalTarget={document.body}
-              menuPlacement={menuPlacement}
-              styles={selectStyles}
-              placeholder={disabled ? "Disabled..." : placeholder ?? "Select one or more options..."}
-              formatGroupLabel={(group) => <GroupLabel {...{ group }} />}
-              components={isClearable ? { ClearIndicator } : undefined}
-            />
-            {errors[name] && !hideErrorMessage && <ErrorMessage message={errors[name]?.message as string} />}
-          </>
-        );
-      }}
-    />
+    <div ref={containerRef}>
+      <Controller
+        {...{ control, name, defaultValue }}
+        rules={validation}
+        render={({ field: { onChange, value } }) => {
+          return (
+            <>
+              <ReactSelect
+                aria-label={ariaLabel}
+                inputId={id}
+                value={value ?? ""}
+                className={clsx(styles.select, errors[name] && styles.error)}
+                isDisabled={disabled}
+                {...{ options, onChange, errors, isClearable }}
+                menuPortalTarget={document.body}
+                menuPlacement={menuPlacement}
+                styles={selectStyles}
+                placeholder={disabled ? "Disabled..." : placeholder ?? "Select one or more options..."}
+                formatGroupLabel={(group) => <GroupLabel {...{ group }} />}
+                components={isClearable ? { ClearIndicator } : undefined}
+              />
+              {errors[name] && !hideErrorMessage && <ErrorMessage message={errors[name]?.message as string} />}
+            </>
+          );
+        }}
+      />
+    </div>
   );
 };
 


### PR DESCRIPTION
Allows passing custom attributes to the clear indicator via the new `clearIndicatorAttributes` prop. This change also refactors the internal attribute assignment to use container refs instead of global document queries, ensuring better isolation between component instances.
